### PR TITLE
Fix Pharo logo URL

### DIFF
--- a/repository/Zinc-HTTP.package/ZnEasy.class/README.md
+++ b/repository/Zinc-HTTP.package/ZnEasy.class/README.md
@@ -8,7 +8,7 @@ For most requests, I return a response object.
 
 For a couple of message, I return an image Form.
 
-	ZnEasy getPng: 'http://www.pharo-project.org/images/pharo.png'.
+	ZnEasy getPng: 'http://pharo.org/files/pharo.png'.
 
 For my implementation I use ZnClient, a full featured HTTP client.
 

--- a/repository/Zinc-HTTP.package/ZnEasy.class/class/getPng..st
+++ b/repository/Zinc-HTTP.package/ZnEasy.class/class/getPng..st
@@ -1,6 +1,6 @@
 operations
 getPng: urlObject
-	"self getPng: 'http://www.pharo-project.org/images/pharo.png'."
+	"self getPng: 'http://pharo.org/files/pharo.png'."
 	"(ZnEasy getPng: 'http://chart.googleapis.com/chart?cht=tx&chl=',
 		'a^2+b^2=c^2' encodeForHTTP) asMorph openInHand."
 	

--- a/repository/Zinc-HTTP.package/ZnImageExampleDelegate.class/instance/downloadPharoLogo.st
+++ b/repository/Zinc-HTTP.package/ZnImageExampleDelegate.class/instance/downloadPharoLogo.st
@@ -1,5 +1,5 @@
 accessing
 downloadPharoLogo
 	^ ZnClient new beOneShot
-		get: 'http://www.pharo-project.org/images/pharo.png';
+		get: 'http://pharo.org/files/pharo.png';
 		entity

--- a/zinc-http-components-paper.md
+++ b/zinc-http-components-paper.md
@@ -38,7 +38,7 @@ An HTML resource will have a mime-type like 'text/html;charset=utf-8'.
 
 To specify which resource you want, a URL (Uniform Resource Locator) is used.
 Web addresses are the most common form of URL.
-For example, <http://www.pharo-project.org/images/pharo.png>, is a URL that referes to a PNG image resource on a specific server.
+For example, <http://pharo.org/files/pharo.png>, is a URL that referes to a PNG image resource on a specific server.
 
 The reliable transport connection between an HTTP client and server is used bidirectionally:
 both to send the request as well as to receive the response.
@@ -708,7 +708,7 @@ A nice feature here, more as an example, are some direct ways to ask for image r
 
     ZnEasy getGif: 'http://homepage.mac.com/svc/ADayAtTheBeach/calculator.gif'.
     ZnEasy getJpeg: 'http://caretaker.wolf359.be/sun-fire-x2100.jpg'.
-    ZnEasy getPng: 'http://www.pharo-project.org/images/pharo.png'.
+    ZnEasy getPng: 'http://pharo.org/files/pharo.png'.
 
     (ZnEasy getPng: 'http://chart.googleapis.com/chart?cht=tx&chl=',
       'a^2+b^2=c^2' encodeForHTTP) asMorph openInHand.


### PR DESCRIPTION
Since the homepage of the Pharo website moved to pharo.org, this URL no
longer redirects to a PNG file:

    $ curl -I http://www.pharo-project.org/images/pharo.png
    HTTP/1.1 301 Moved Permanently
    Date: Wed, 04 May 2016 22:41:57 GMT
    Server: Apache/2.2.22 (Debian)
    Location: http://pharo.org/
    Vary: Accept-Encoding
    Content-Type: text/html; charset=iso-8859-1