### PR TITLE
MIME documents should use CRLF line ending to meet RFC 2045, however …

### DIFF
--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/README.md
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/README.md
@@ -1,0 +1,20 @@
+ZnCRLFReadStream wraps a binary stream with any of the common line endings (CR, LF, CRLF) and converts them to CRLF.
+
+RFC 2045 (https://tools.ietf.org/html/rfc2045) states that MIME documents use CRLF as the line end marker, however email documents as stored on disk often use the local line enging, e.g. LF.
+
+
+Public API and Key Messages
+
+- on: - supply the stream to be wrapped
+- The public API is the standard Stream API
+
+   One simple example is simply gorgeous.
+ 
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	next:			<Integer>
+	stream:		<BinaryStream>
+
+
+    Implementation Points

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/class/initialize.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/class/initialize.st
@@ -1,0 +1,5 @@
+class initialization
+initialize 
+
+	Cr := Character cr asInteger.
+	Lf := Character lf asInteger.

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/class/on..st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/class/on..st
@@ -1,0 +1,4 @@
+instance creation
+on: aBinaryReadStream
+
+	^self new on: aBinaryReadStream 

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/atEnd.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/atEnd.st
@@ -1,0 +1,4 @@
+accessing
+atEnd 
+
+	^stream atEnd

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/close.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/close.st
@@ -1,0 +1,4 @@
+open/close
+close 
+
+	stream close

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/initialize.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/initialize.st
@@ -1,0 +1,5 @@
+accessing
+initialize 
+
+	super initialize.
+	next := nil.

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/isBinary.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/isBinary.st
@@ -1,0 +1,4 @@
+accessing
+isBinary 
+
+	^true

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/next.into..st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/next.into..st
@@ -1,0 +1,6 @@
+accessing
+next: n into: aCollection
+	"Read n objects into the given collection.
+	Return aCollection or a partial copy if less than
+	n elements have been read."
+	^self next: n into: aCollection startingAt: 1

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/next.into.startingAt..st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/next.into.startingAt..st
@@ -1,0 +1,10 @@
+accessing
+next: requestedCount into: aCollection startingAt: startIndex
+	"Read requestedCount objects into the given collection. 
+	Return aCollection or a partial copy if less elements have been read."
+
+	| readCount |
+	readCount := self readInto: aCollection startingAt: startIndex count: requestedCount.
+	^ readCount = requestedCount
+		ifTrue: [ ^ aCollection ]
+		ifFalse: [ ^ aCollection copyFrom: 1 to: startIndex + readCount - 1 ]

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/next.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/next.st
@@ -1,0 +1,23 @@
+accessing
+next
+	"Answer the next character from the stream, converting end-of-lines to CRLF"
+
+	| byte |
+
+	next ifNotNil:
+		[ byte := next.
+		next := nil.
+		^byte ].
+	stream atEnd ifTrue: [ ^nil ].
+	(byte := stream next) ifNil: [ ^nil ].
+	byte == Cr ifTrue:
+		"Consume the Cr and ensure that a Lf is answered next.
+		If the following character is Lf, consume it."
+		[ stream peek == Lf ifTrue:
+			[ stream next ].
+		next := Lf ]
+	ifFalse: [ byte == Lf ifTrue:
+		[ "Answer a Cr instead, and then a Lf"
+		byte := Cr.
+		next := Lf ] ].
+	^byte

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/on..st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/on..st
@@ -1,0 +1,5 @@
+accessing
+on: aBinaryReadStream
+
+	self assert: aBinaryReadStream isBinary.
+	stream := aBinaryReadStream 

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/peek.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/peek.st
@@ -1,0 +1,11 @@
+accessing
+peek
+	"Answer the next character from the stream, converting end-of-lines to CRLF"
+
+	| byte |
+
+	next ifNotNil:	[ ^next ].
+	stream atEnd ifTrue: [ ^nil ].
+	(byte := stream peek) ifNil: [ ^nil ].
+	byte == Lf ifTrue: [ ^Cr ].
+	^byte

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/readInto.startingAt.count..st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/readInto.startingAt.count..st
@@ -1,0 +1,7 @@
+accessing
+readInto: collection startingAt: offset count: requestedCount
+
+	0 to: requestedCount - 1 do: [ :count | | byte |
+		(byte := self next) ifNil: [ ^ count ].  
+		collection at: offset + count put: byte ].
+	^ requestedCount

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/upToEnd.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/instance/upToEnd.st
@@ -1,0 +1,7 @@
+accessing
+upToEnd 
+	"Answer a ByteArray of the stream from the current position to the last"
+
+	^ByteArray streamContents: [ :newStream | | nextByte |
+		[ (nextByte := self next) isNil ] whileFalse:
+			[ newStream nextPut: nextByte ] ]

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/properties.json
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCRLFReadStream.class/properties.json
@@ -1,0 +1,17 @@
+{
+	"commentStamp" : "AlistairGrant 5/5/2019 19:04",
+	"super" : "Object",
+	"category" : "Zinc-Character-Encoding-Core",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [
+		"Cr",
+		"Lf"
+	],
+	"instvars" : [
+		"stream",
+		"next"
+	],
+	"name" : "ZnCRLFReadStream",
+	"type" : "normal"
+}

--- a/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Zinc-Character-Encoding-Core'!
+SystemOrganization addCategory: 'Zinc-Character-Encoding-Core'!

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnCRLFReadStreamTest.class/instance/testBasicStream.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnCRLFReadStreamTest.class/instance/testBasicStream.st
@@ -1,0 +1,25 @@
+tests
+testBasicStream 
+
+	| lines input output |
+
+	lines := #('Line 1' 'Line 2' 'Line 3').
+	input := String streamContents: [ :stream |
+		stream
+			<< lines first;
+			<< String cr;
+			<< lines second;
+			<< String lf;
+			<< lines third;
+			<< String crlf ].
+	output := String streamContents: [ :stream |
+		stream
+			<< lines first;
+			<< String crlf;
+			<< lines second;
+			<< String crlf;
+			<< lines third;
+			<< String crlf ].
+	self 
+		assert: (ZnCRLFReadStream on: input asByteArray readStream) upToEnd 
+		equals: output asByteArray.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnCRLFReadStreamTest.class/instance/testDoubleEnding.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnCRLFReadStreamTest.class/instance/testDoubleEnding.st
@@ -1,0 +1,31 @@
+tests
+testDoubleEnding
+
+	| lines input output |
+
+	lines := #('Line 1' 'Line 2' 'Line 3').
+	input := String streamContents: [ :stream |
+		stream
+			<< lines first;
+			<< String cr;
+			<< String cr;
+			<< lines second;
+			<< String lf;
+			<< String lf;
+			<< lines third;
+			<< String crlf;
+			<< String crlf ].
+	output := String streamContents: [ :stream |
+		stream
+			<< lines first;
+			<< String crlf;
+			<< String crlf;
+			<< lines second;
+			<< String crlf;
+			<< String crlf;
+			<< lines third;
+			<< String crlf;
+			<< String crlf ].
+	self 
+		assert: (ZnCRLFReadStream on: input asByteArray readStream) upToEnd 
+		equals: output asByteArray.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnCRLFReadStreamTest.class/instance/testPeek.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnCRLFReadStreamTest.class/instance/testPeek.st
@@ -1,0 +1,35 @@
+tests
+testPeek
+
+	| input stream |
+
+	input := String streamContents: [ :str |
+		str
+			<< 'a';
+			<< String cr;
+			<< 'b';
+			<< String lf;
+			<< 'c';
+			<< String crlf ].
+	stream := ZnCRLFReadStream on: input asByteArray readStream.
+	self 
+		assert: stream peek
+		equals: $a asInteger.
+	self
+		assert: stream next 
+		equals: $a asInteger.
+	self
+		assert: stream next 
+		equals: Character cr asInteger.
+	self
+		assert: stream peek
+		equals: Character lf asInteger.
+	self
+		assert: stream next
+		equals: Character lf asInteger.
+	self
+		assert: stream peek
+		equals: $b asInteger.
+	self
+		assert: stream next
+		equals: $b asInteger.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnCRLFReadStreamTest.class/properties.json
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnCRLFReadStreamTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "Zinc-Character-Encoding-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "ZnCRLFReadStreamTest",
+	"type" : "normal"
+}

--- a/repository/Zinc-Character-Encoding-Tests.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Zinc-Character-Encoding-Tests'!
+SystemOrganization addCategory: 'Zinc-Character-Encoding-Tests'!


### PR DESCRIPTION
…many email documents (which are MIME encoded) fail to do this and use the local line ending convention, e.g. LF.

ZnCRLFReadStream wraps a binary stream and converts the three common line endings, i.e. LF, CR and CRLF, to CRLF.

An alternate approach would be to make the MIME parsing classes more forgiving and accept any of the common line endings, however MIME can embed other formats within its contents, and it isn't clear whether always accepting any line ending is safe. Wrapping the stream allows the a parser to be strict while providing the flexibility to accept local line endings if desired.

Fixes: https://github.com/pharo-project/pharo/issues/3299