### PR TITLE
Add ZnBase64UrlEncoder that does base64url encoding/decoding 

### DIFF
--- a/repository/Zinc-Character-Encoding-Core.package/ZnBase64UrlEncoder.class/README.md
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnBase64UrlEncoder.class/README.md
@@ -1,0 +1,3 @@
+I provide base64url encoding/decoding as specified in RFC 4648 section 5, "Base 64 Encoding with URL and Filename Safe Alphabet".
+
+The encoding is technically identical to what is usually known as Base64 encoding, except that $- is used in place of $+ and $_ in place of $/. Also, if the data length is known implicitly,  padding by $= can be skipped. 

--- a/repository/Zinc-Character-Encoding-Core.package/ZnBase64UrlEncoder.class/class/initialize.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnBase64UrlEncoder.class/class/initialize.st
@@ -1,0 +1,9 @@
+class initialization
+initialize
+
+	DefaultAlphabet2 := String withAll: ($A to: $Z) , ($a to: $z) , ($0 to: $9) , #($- $_).
+	DefaultInverse2 := Array new: 128.
+	0 to: 127 do: [ :each | 
+		| offset |
+		offset := DefaultAlphabet2 indexOf: each asCharacter ifAbsent: [ nil ].
+		DefaultInverse2 at: each + 1 put: (offset ifNotNil: [ offset - 1 ]) ]

--- a/repository/Zinc-Character-Encoding-Core.package/ZnBase64UrlEncoder.class/instance/decode.to..st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnBase64UrlEncoder.class/instance/decode.to..st
@@ -1,0 +1,15 @@
+converting
+decode: stringStream to: byteStream
+	| char1 char2 char3 char4 |
+	[ stringStream atEnd ] whileFalse: [ 
+		self skipWhitespace: stringStream.
+		stringStream atEnd ifTrue: [ ^ self ].
+		char1 := stringStream next.
+		char2 := stringStream next.
+		char3 := stringStream next.
+		(char3 isNil) ifTrue: [ char3 := padding ].
+		char4 := stringStream next.
+		(char4 isNil) ifTrue: [ char4 := padding ].
+		((char1 isNil | char2 isNil) or: [ strict and: [ char3 isNil | char4 isNil ] ])
+			ifTrue: [ ZnCharacterEncodingError signal: 'Illegal Base64 input' ].
+		self decode: char1 and: char2 and: char3 and: char4 to: byteStream ]

--- a/repository/Zinc-Character-Encoding-Core.package/ZnBase64UrlEncoder.class/instance/initialize.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnBase64UrlEncoder.class/instance/initialize.st
@@ -1,0 +1,6 @@
+initialization
+initialize
+
+	super initialize.
+	alphabet := DefaultAlphabet2.
+	inverse := DefaultInverse2 

--- a/repository/Zinc-Character-Encoding-Core.package/ZnBase64UrlEncoder.class/properties.json
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnBase64UrlEncoder.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"commentStamp" : "PierceNg 5/23/2019 17:51",
+	"super" : "ZnBase64Encoder",
+	"category" : "Zinc-Character-Encoding-Core",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [
+		"DefaultAlphabet2",
+		"DefaultInverse2"
+	],
+	"instvars" : [ ],
+	"name" : "ZnBase64UrlEncoder",
+	"type" : "normal"
+}

--- a/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: 'Zinc-Character-Encoding-Core'!
+SystemOrganization addCategory: #'Zinc-Character-Encoding-Core'!

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/encoderClass.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/encoderClass.st
@@ -1,0 +1,3 @@
+accessing
+encoderClass 
+	^ ZnBase64Encoder

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testCustomAlphabetFullSpectrum.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testCustomAlphabetFullSpectrum.st
@@ -1,7 +1,7 @@
 testing
 testCustomAlphabetFullSpectrum
 	| encoder input output |
-	encoder := ZnBase64Encoder new.
+	encoder := self encoderClass new.
 	encoder standardAlphabetWith: $- and: $_.
 	encoder noPadding; beLenient. 
 	input := (0 to: 255) asByteArray , (255 to: 0) asByteArray.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testCustomLineBreaking.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testCustomLineBreaking.st
@@ -1,7 +1,7 @@
 testing
 testCustomLineBreaking
 	| encoder input output charCount |
-	encoder := ZnBase64Encoder new.
+	encoder := self encoderClass new.
 	encoder breakLinesAt: 16.
 	input := (0 to: 255) asByteArray.
 	output := encoder encode: input.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testEmpty.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testEmpty.st
@@ -1,7 +1,7 @@
 testing
 testEmpty
 	| encoder |
-	encoder := ZnBase64Encoder new.
+	encoder := self encoderClass new.
 	self 
 		assert: (encoder encode: #[])
 		equals: ''.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testFullAlphabet.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testFullAlphabet.st
@@ -1,7 +1,7 @@
 testing
 testFullAlphabet
 	| encoder input output |
-	encoder := ZnBase64Encoder new.
+	encoder := self encoderClass new.
 	input := encoder alphabet.
 	output := encoder decode: input.
 	self assert: (encoder encode: output) equals: input.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testFullSpectrum.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testFullSpectrum.st
@@ -1,7 +1,7 @@
 testing
 testFullSpectrum
 	| encoder input output |
-	encoder := ZnBase64Encoder new.
+	encoder := self encoderClass new.
 	input := (0 to: 255) asByteArray , (255 to: 0) asByteArray.
 	output := encoder encode: input.
 	self assert: (encoder decode: output) equals: input.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testPadding.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testPadding.st
@@ -1,7 +1,7 @@
 testing
 testPadding
 	| encoder |
-	encoder := ZnBase64Encoder new.
+	encoder := self encoderClass new.
 	self assert: (encoder encode: 'M' asByteArray) equals: 'TQ=='.
 	self assert: (encoder decode: 'TQ==') equals: 'M' asByteArray.
 	self assert: (encoder encode: 'Ma' asByteArray) equals: 'TWE='.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testQuote.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testQuote.st
@@ -1,7 +1,7 @@
 testing
 testQuote
 	| input output encoder break |
-	encoder := ZnBase64Encoder new lineEndConvention: #cr; breakLines; yourself.
+	encoder := self encoderClass new lineEndConvention: #cr; breakLines; yourself.
 	input := 'Man is distinguished, not only by his reason, but by this singular passion from other animals, which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure.'.
 	break := String with: Character cr.
 	output := 'TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz' , break 

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testSimple.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testSimple.st
@@ -1,7 +1,7 @@
 testing
 testSimple
 	| encoder |
-	encoder := ZnBase64Encoder new.
+	encoder := self encoderClass new.
 	self 
 		assert: (encoder encode: 'Man' asByteArray)
 		equals: 'TWFu'.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testWhitespaceAtEnd.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64EncoderTests.class/instance/testWhitespaceAtEnd.st
@@ -1,7 +1,7 @@
 testing
 testWhitespaceAtEnd
 	| encoder |
-	encoder := ZnBase64Encoder new.
+	encoder := self encoderClass new.
 	"whitespace is #any non-alphabet character"
 	self assert: (encoder decode: 'TQ==' , String lf) equals: 'M' asByteArray.
 	encoder whitespace: #separator.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64UrlEncoderTests.class/class/shouldInheritSelectors.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64UrlEncoderTests.class/class/shouldInheritSelectors.st
@@ -1,0 +1,3 @@
+testing
+shouldInheritSelectors
+	^ true

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64UrlEncoderTests.class/instance/encoderClass.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64UrlEncoderTests.class/instance/encoderClass.st
@@ -1,0 +1,3 @@
+accessing
+encoderClass 
+	^ ZnBase64UrlEncoder

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64UrlEncoderTests.class/instance/testDecodingErrors.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64UrlEncoderTests.class/instance/testDecodingErrors.st
@@ -1,10 +1,11 @@
-testing
+tests
 testDecodingErrors
 	| encoder |
 	encoder := self encoderClass new.
 	self should: [ encoder decode: 'A' ] raise: ZnCharacterEncodingError.
-	self should: [ encoder decode: 'AB' ] raise: ZnCharacterEncodingError.
-	self should: [ encoder decode: 'ABC' ] raise: ZnCharacterEncodingError.
+	"Next two are valid decodings."
+	"self should: [ encoder decode: 'AB' ] raise: ZnCharacterEncodingError.
+	self should: [ encoder decode: 'ABC' ] raise: ZnCharacterEncodingError."
 	encoder whitespace: #separator.
 	self should: [ encoder decode: '*' ] raise: ZnCharacterEncodingError.
 	self should: [ encoder decode: '**' ] raise: ZnCharacterEncodingError.

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64UrlEncoderTests.class/instance/testDifferent.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64UrlEncoderTests.class/instance/testDifferent.st
@@ -1,0 +1,13 @@
+tests
+testDifferent
+	| encoder jsonb64 json |
+	jsonb64 := 'eyJraWQiOiJyc2ExIiwiYWxnIjoiUlMyNTYifQ'.
+	json := '{"kid":"rsa1","alg":"RS256"}'. "This is the decoded JSON string."
+	encoder := ZnBase64Encoder new.
+	self 
+		should: [ encoder decode: jsonb64 ]
+		raise: ZnCharacterEncodingError.
+	encoder := ZnBase64UrlEncoder	new.
+	self
+		assert: (encoder decode: jsonb64) 
+		equals:  json asByteArray 

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBase64UrlEncoderTests.class/properties.json
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBase64UrlEncoderTests.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "ZnBase64EncoderTests",
+	"category" : "Zinc-Character-Encoding-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "ZnBase64UrlEncoderTests",
+	"type" : "normal"
+}

--- a/repository/Zinc-Character-Encoding-Tests.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: 'Zinc-Character-Encoding-Tests'!
+SystemOrganization addCategory: #'Zinc-Character-Encoding-Tests'!


### PR DESCRIPTION
as specified in RFC 4648 section 5, "Base 64 Encoding with URL and Filename Safe Alphabet".

See the test case #testDifferent.

A further refactoring could be to make DefaultAlphabet and DefaultInverse class instance variables. For now I've used separate class variables in ZnBase64UrlEncoder.