### PR TITLE
Added a test case to ZnMimeType covering hash calculation for mime ty…

### DIFF
--- a/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testCharset.st
+++ b/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testCharset.st
@@ -2,10 +2,10 @@ testing
 testCharset
 	| mimeType |
 	mimeType := ZnMimeType textPlain.
-	self assert: mimeType charSet = 'utf-8'.
+	self assert: mimeType charSet equals: 'utf-8'.
 	mimeType charSet: 'ascii'.
-	self assert: mimeType charSet = 'ascii'.
+	self assert: mimeType charSet equals: 'ascii'.
 	mimeType clearCharSet.
 	self assert: mimeType charSet isNil.
 	mimeType setCharSetUTF8.
-	self assert: mimeType charSet = 'utf-8'
+	self assert: mimeType charSet equals: 'utf-8'

--- a/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testComparingWithParameters.st
+++ b/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testComparingWithParameters.st
@@ -1,0 +1,12 @@
+tests
+testComparingWithParameters
+
+	| mimeType equalMimeType |
+
+	mimeType := ZnMimeType fromString: 'application/json;q=1'.
+	equalMimeType := ZnMimeType applicationJson parameterAt: 'q' put: '1'.
+
+	self
+		assert: mimeType equals: equalMimeType;
+		assert: mimeType hash equals: equalMimeType hash;
+		deny: mimeType equals: ZnMimeType applicationJson

--- a/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testCopying.st
+++ b/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testCopying.st
@@ -3,13 +3,12 @@ testCopying
 	| mimeType1 mimeType2 |
 	mimeType1 := ZnMimeType textPlain.
 	mimeType2 := ZnMimeType textPlain.
-	self assert: mimeType1 = mimeType2.
-	self assert: mimeType1 parameters = mimeType2 parameters.
+	self assert: mimeType1 equals: mimeType2.
+	self assert: mimeType1 parameters equals: mimeType2 parameters.
 	mimeType1 charSet: 'utf-8'.
-	self assert: mimeType1 charSet = 'utf-8'.
+	self assert: mimeType1 charSet equals: 'utf-8'.
 	mimeType2 charSet: 'latin1'.
-	self assert: mimeType2 charSet = 'latin1'.
+	self assert: mimeType2 charSet equals: 'latin1'.
 	self assert: (mimeType1 matches: mimeType2).
 	self deny: mimeType1 parameters = mimeType2 parameters.
-	self deny: mimeType1 charSet = mimeType2 charSet.
-	
+	self deny: mimeType1 charSet = mimeType2 charSet

--- a/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testDefault.st
+++ b/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testDefault.st
@@ -1,3 +1,3 @@
 testing
 testDefault
-	self assert: ZnMimeType default = ZnMimeType applicationOctetStream
+	self assert: ZnMimeType default equals: ZnMimeType applicationOctetStream

--- a/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testIdentity.st
+++ b/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testIdentity.st
@@ -1,3 +1,3 @@
 testing
 testIdentity
-	self assert: ZnMimeType textPlain = ZnMimeType textPlain
+	self assert: ZnMimeType textPlain equals: ZnMimeType textPlain

--- a/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testParameters.st
+++ b/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testParameters.st
@@ -3,11 +3,11 @@ testParameters
 	| mimeType |
 	mimeType := ZnMimeType main: 'text' sub: 'plain'.
 	self should: [ mimeType parameterAt: 'foo' ] raise: KeyNotFound.
-	self assert: (mimeType parameterAt: 'foo' ifAbsent: [ #none ]) = #none.
+	self assert: (mimeType parameterAt: 'foo' ifAbsent: [ #none ]) equals: #none.
 	mimeType parameterAt: 'foo' put: '1'.
-	self assert: (mimeType parameterAt: 'foo') = '1'.
-	self assert: (mimeType parameterAt: 'foo' ifAbsent: [ #none ]) = '1'.
+	self assert: (mimeType parameterAt: 'foo') equals: '1'.
+	self assert: (mimeType parameterAt: 'foo' ifAbsent: [ #none ]) equals: '1'.
 	mimeType removeParameter: 'foo'.
 	mimeType removeParameter: 'bar'.
 	self should: [ mimeType parameterAt: 'foo' ] raise: KeyNotFound.
-	self assert: (mimeType parameterAt: 'foo' ifAbsent: [ #none ]) = #none	
+	self assert: (mimeType parameterAt: 'foo' ifAbsent: [ #none ]) equals: #none	

--- a/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testReading.st
+++ b/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testReading.st
@@ -2,8 +2,8 @@ testing
 testReading
 	| mimeType |
 	mimeType := ZnMimeType fromString: 'text/plain; charset=utf-8'.
-	self assert: (mimeType main = 'text').
-	self assert: (mimeType sub = 'plain').
-	self assert: (mimeType charSet = 'utf-8').
+	self assert: mimeType main equals: 'text'.
+	self assert: mimeType sub equals: 'plain'.
+	self assert: mimeType charSet equals: 'utf-8'.
 	self assert: mimeType isCharSetUTF8.
 	self assert: mimeType isBinary not

--- a/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testWriting.st
+++ b/repository/Zinc-Resource-Meta-Tests.package/ZnMimeTypeTests.class/instance/testWriting.st
@@ -3,6 +3,6 @@ testWriting
 	| mimeType |
 	(mimeType := ZnMimeType main: 'text' sub: 'plain')
 		charSet: 'utf-8'.
-	self assert: mimeType printString = 'text/plain;charset=utf-8'.
+	self assert: mimeType printString equals: 'text/plain;charset=utf-8'.
 	self assert: mimeType isCharSetUTF8.
 	self assert: mimeType isBinary not


### PR DESCRIPTION
…pes with parameteres.

This was broken in the pharo repo: See pharo-project/pharo#4255.
Also use assert:equals: when possible.