### PR TITLE
Store the offending buffer in ZnCharacterEncodingError when there is …

### DIFF
--- a/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncoder.class/instance/decodeBytes..st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncoder.class/instance/decodeBytes..st
@@ -4,6 +4,8 @@ decodeBytes: bytes
 	
 	| byteStream |
 	byteStream := bytes readStream.
-	^ String streamContents: [ :stream |
+	^ [ String streamContents: [ :stream |
 		[ byteStream atEnd ] whileFalse: [
-			stream nextPut: (self nextFromStream: byteStream) ] ] 
+			stream nextPut: (self nextFromStream: byteStream) ] ] ]
+				on: ZnCharacterEncodingError 
+				do: [ :ex | ex buffer: bytes. ex pass ]

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncodingError.class/README.md
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncodingError.class/README.md
@@ -1,6 +1,6 @@
 I am ZnCharacterEncodingError.
 I am an Error.
 
-I signal when something goes wrong while encoding or decoding characters.
+I signal when something goes wrong while encoding or decoding characters.  If possible, the buffer that contains the badly encoded characters will be set in the buffer instance variable.
 
 Part of Zinc HTTP Components

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncodingError.class/instance/buffer..st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncodingError.class/instance/buffer..st
@@ -1,0 +1,3 @@
+accessing
+buffer: anObject
+	buffer := anObject

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncodingError.class/instance/buffer.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncodingError.class/instance/buffer.st
@@ -1,0 +1,3 @@
+accessing
+buffer
+	^ buffer

--- a/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncodingError.class/properties.json
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncodingError.class/properties.json
@@ -1,11 +1,13 @@
 {
-	"commentStamp" : "",
+	"commentStamp" : "AlistairGrant 9/23/2019 08:49",
 	"super" : "Error",
 	"category" : "Zinc-Character-Encoding-Core",
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],
-	"instvars" : [ ],
+	"instvars" : [
+		"buffer"
+	],
 	"name" : "ZnCharacterEncodingError",
 	"type" : "normal"
 }

--- a/repository/Zinc-Character-Encoding-Core.package/ZnUTFEncoder.class/instance/decodeBytes..st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnUTFEncoder.class/instance/decodeBytes..st
@@ -5,7 +5,7 @@ decodeBytes: bytes
 	
 	| byteStream |
 	byteStream := bytes readStream.
-	^ String streamContents: [ :stream |
+	^ [ String streamContents: [ :stream |
 		[ byteStream atEnd ] whileFalse: [ | codePoint |
 			codePoint := self nextCodePointFromStream: byteStream.
 			(codePoint > 255 and: [ stream originalContents isWideString not ])
@@ -13,4 +13,6 @@ decodeBytes: bytes
 					position := stream position.
 					wideString := WideString from: stream originalContents.
 					stream on: wideString; setFrom: position + 1 to: position ].
-			stream nextPut: (Character value: codePoint) ] ] 
+			stream nextPut: (Character value: codePoint) ] ] ]
+				on: ZnCharacterEncodingError 
+				do: [ :ex | ex buffer: bytes. ex pass ]

--- a/repository/Zinc-Character-Encoding-Core.package/ZnUTFEncoder.class/instance/decodeBytesIntoWideString..st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnUTFEncoder.class/instance/decodeBytesIntoWideString..st
@@ -4,6 +4,8 @@ decodeBytesIntoWideString: bytes
 
 	| byteStream |
 	byteStream := bytes readStream.
-	^ WideString streamContents: [ :stream |
+	^ [ WideString streamContents: [ :stream |
 		[ byteStream atEnd ] whileFalse: [
-			stream nextPut: (self nextFromStream: byteStream) ] ] 
+			stream nextPut: (self nextFromStream: byteStream) ] ] ]
+				on: ZnCharacterEncodingError 
+				do: [ :ex | ex buffer: bytes. ex pass ]


### PR DESCRIPTION
…an encoding error.

This allows the calling method (which may be much further up the stack and unable to influence the character decoding used) to act on the buffer, e.g. decode it using an alternative strategy.

Fixes: https://github.com/pharo-project/pharo/issues/4687