### PR TITLE
new test method testAcceptsEncodingGzip

### DIFF
--- a/repository/Zinc-Tests.package/ZnRequestTest.class/instance/testAcceptsEncodingGzip.st
+++ b/repository/Zinc-Tests.package/ZnRequestTest.class/instance/testAcceptsEncodingGzip.st
@@ -1,0 +1,6 @@
+tests
+testAcceptsEncodingGzip
+	| request |
+	request := ZnRequest new.
+	request setAcceptEncodingGzip.
+	self assert: request acceptsEncodingGzip


### PR DESCRIPTION
I submit this pull request to suggest a test method `ZnRequestTest >> testAcceptsEncodingGzip`.

We noticed that the methods #setAcceptEncodingGzip and #acceptsEncodingGzip are never executed by any of the tests in ZnRequestTest. 

Note that these suggestions are adapted from a test amplification tool called SmallAmp (https://github.com/mabdi/small-amp). SmallAmp executes existing tests, sees which parts of the class under test are not covered and then suggests improvements on the test methods.

I hope you will accept this pull request. It would illustrate that SmallAmp makes relevant suggestions.

Mehrdad Abdi.
