### PR TITLE
Basic authentication, fix parsing credentials

### DIFF
--- a/repository/Zinc-REST.package/ZnRestServerUtils.class/class/extractBasicAuthorization..st
+++ b/repository/Zinc-REST.package/ZnRestServerUtils.class/class/extractBasicAuthorization..st
@@ -1,8 +1,8 @@
 utils
 extractBasicAuthorization: request
-	| authorization |
+	| authorization decodedCredentials indexOfColon |
 	authorization := (request headers at: 'Authorization' ifAbsent: [ ^ nil ]) findTokens: ' '.
 	(authorization size = 2 and: [ authorization first = 'Basic' ]) ifFalse: [ ^ nil ].
-	authorization :=  (ZnUtils decodeBase64: authorization second) findTokens: ':'.
-	authorization size = 2 ifFalse: [ ^ nil ].
-	^ authorization first -> authorization second
+	decodedCredentials := ZnUtils decodeBase64: authorization second.
+	indexOfColon := decodedCredentials indexOf: $: ifAbsent: [ ^ nil ].
+	^ (decodedCredentials first: indexOfColon - 1) -> (decodedCredentials allButFirst: indexOfColon)


### PR DESCRIPTION
In  basic Authentication credentials, a username cannot contain the character ":" but a password can.

See https://en.wikipedia.org/wiki/Basic_access_authentication

"The username and password are combined with a single colon (:). This means that the username itself cannot contain a colon."