### PR TITLE
Add support for file URLs that do not specify a host

### DIFF
--- a/repository/Zinc-Resource-Meta-Core.package/ZnUrl.class/class/schemesNotUsingDoubleSlash.st
+++ b/repository/Zinc-Resource-Meta-Core.package/ZnUrl.class/class/schemesNotUsingDoubleSlash.st
@@ -2,5 +2,5 @@ accessing
 schemesNotUsingDoubleSlash
 	"Most URL schemes use a double slash, as in http://
 	but some don't, return a list of those"
-	
-	^ #( #mailto #telnet )
+	"'file' is a special case as it can appear as both file:// and file:"
+	^ #( #mailto #telnet #file )

--- a/repository/Zinc-Resource-Meta-Tests.package/ZnFileUrlTest.class/instance/testAsZnUrl.st
+++ b/repository/Zinc-Resource-Meta-Tests.package/ZnFileUrlTest.class/instance/testAsZnUrl.st
@@ -8,7 +8,7 @@ testAsZnUrl
 	self assert: fileUrl file equals: 'test.txt'.
 	self assert: fileUrl pathSegments asArray equals: #( 'foo' 'bar' 'test.txt').
 	self assert: fileUrl pathPrintString equals: '/foo/bar/test.txt'.
-	self assert: fileUrl printString equals: 'file:///foo/bar/test.txt'.
+	self assert: fileUrl printString equals: 'file:/foo/bar/test.txt'.
 	self deny: fileUrl hasHost.
 	self deny: fileUrl hasPort.
 	self deny: fileUrl hasQuery.

--- a/repository/Zinc-Resource-Meta-Tests.package/ZnUrlTest.class/instance/testFileUrlNoSpecifiedHost.st
+++ b/repository/Zinc-Resource-Meta-Tests.package/ZnUrlTest.class/instance/testFileUrlNoSpecifiedHost.st
@@ -1,7 +1,7 @@
 testing
-testFileUrl
+testFileUrlNoSpecifiedHost
 	| url |
-	url := 'file://localhost/users/Sven/Desktop/foo.txt' asZnUrl.
+	url := 'file:/users/Sven/Desktop/foo.txt' asZnUrl.
 	self assert: url isFile.
-	self assert: url host equals: 'localhost'.
+	self assert: url host isNil.
 	self assert: url pathSegments equals: #( 'users' 'Sven' 'Desktop' 'foo.txt' ) asOrderedCollection 

--- a/repository/Zinc-Resource-Meta-Tests.package/ZnUrlTest.class/instance/testFileUrlWithSpecifiedHost.st
+++ b/repository/Zinc-Resource-Meta-Tests.package/ZnUrlTest.class/instance/testFileUrlWithSpecifiedHost.st
@@ -1,0 +1,7 @@
+testing
+testFileUrlWithSpecifiedHost
+	| url |
+	url := 'file://localhost/users/Sven/Desktop/foo.txt' asZnUrl.
+	self assert: url isFile.
+	self assert: url host equals: 'localhost'.
+	self assert: url pathSegments equals: #( 'users' 'Sven' 'Desktop' 'foo.txt' ) asOrderedCollection 


### PR DESCRIPTION
Add support for file URLs that do not specify a host, i.e. 'file:/home/user/filename.ext', as allowed by RFC 8089.