### PR TITLE
Centralize JSON parser choice in ZnUtils

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Bash needs lf even on windows/cygwin
+*.st eol=lf
+*.sh eol=lf
+
+# st files are always text, even if they contain invalid encoded chars
+*.st text diff
+
+# GitHub is unable to properly detect Smalltalk code, so help it a bit
+*.st linguist-language=Smalltalk

--- a/repository/Zinc-HTTP.package/ZnClient.class/instance/forJsonREST.st
+++ b/repository/Zinc-HTTP.package/ZnClient.class/instance/forJsonREST.st
@@ -1,21 +1,9 @@
 initialization
 forJsonREST
-	"Configure me for JSON REST interaction: I assume that the entities that I read and write are JSON.
-	This requires either NeoJSON or STON to be present."
 
 	| reader writer |
-	reader := self class environment
-		at: #NeoJSONObject
-		ifAbsent: [ 
-			self class environment 
-				at: #STONJSON 
-				ifAbsent: [ self error: 'Could not find a suitabe JSON parser' ] ].
-	writer := self class environment
-		at: #NeoJSONWriter
-		ifAbsent: [ 
-			self class environment 
-				at: #STONJSON 
-				ifAbsent: [ self error: 'Could not find a suitabe JSON writer' ] ].
+	reader := ZnUtils defaultJSONReader.
+	writer := ZnUtils defaultJSONWriter.
 	self
 		accept: ZnMimeType applicationJson;
 		contentReader: [ :entity | reader fromString: entity contents ];

--- a/repository/Zinc-HTTP.package/ZnFileSystemUtils.class/class/binaryFileStreamFor..st
+++ b/repository/Zinc-HTTP.package/ZnFileSystemUtils.class/class/binaryFileStreamFor..st
@@ -3,5 +3,5 @@ binaryFileStreamFor: fileName
 	| fileReference |
 	fileReference := fileName asFileReference.
 	^ (fileReference respondsTo: #binaryReadWriteStream)
-		ifTrue: [ fileReference binaryReadWriteStream ]
+		ifTrue: [ fileReference perform: #binaryReadWriteStream ]
 		ifFalse: [ fileReference writeStream binary ]

--- a/repository/Zinc-HTTP.package/ZnFileSystemUtils.class/properties.json
+++ b/repository/Zinc-HTTP.package/ZnFileSystemUtils.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "SvenVanCaekenberghe 7/11/2018 16:29",
+	"commentStamp" : "",
 	"super" : "Object",
 	"category" : "Zinc-HTTP-Support",
 	"classinstvars" : [ ],

--- a/repository/Zinc-HTTP.package/ZnUtils.class/class/defaultJSONReader.st
+++ b/repository/Zinc-HTTP.package/ZnUtils.class/class/defaultJSONReader.st
@@ -1,0 +1,13 @@
+json
+defaultJSONReader
+	"Configure me for JSON REST interaction: I assume that the entities that I read and write are JSON.
+	This requires either NeoJSON or STON to be present."
+	
+	| reader |
+	reader := self class environment at: #NeoJSONObject ifAbsent: [ 
+		          self class environment
+			          at: #STONJSON
+			          ifAbsent: [ 
+			          self error: 'Could not find a suitabe JSON parser' ] ].
+
+	^ reader

--- a/repository/Zinc-HTTP.package/ZnUtils.class/class/defaultJSONWriter.st
+++ b/repository/Zinc-HTTP.package/ZnUtils.class/class/defaultJSONWriter.st
@@ -1,0 +1,13 @@
+json
+defaultJSONWriter
+	"Configure me for JSON REST interaction: I assume that the entities that I read and write are JSON.
+	This requires either NeoJSON or STON to be present."
+	
+	| writer |
+	writer := self class environment at: #NeoJSONWriter ifAbsent: [ 
+		          self class environment
+			          at: #STONJSON
+			          ifAbsent: [ 
+			          self error: 'Could not find a suitabe JSON writer' ] ].
+
+	^ writer

--- a/repository/Zinc-SSO-OAuth2-Core.package/ZnFacebookOAuth2Session.class/instance/getUserData.st
+++ b/repository/Zinc-SSO-OAuth2-Core.package/ZnFacebookOAuth2Session.class/instance/getUserData.st
@@ -9,4 +9,4 @@ getUserData
 
 	response := ZnClient new get: url.
 	
-	^ NeoJSONReader fromString: response
+	^ ZnUtils defaultJSONReader fromString: response

--- a/repository/Zinc-SSO-OAuth2-Core.package/ZnGoogleOAuth2Session.class/instance/getUserData.st
+++ b/repository/Zinc-SSO-OAuth2-Core.package/ZnGoogleOAuth2Session.class/instance/getUserData.st
@@ -11,4 +11,4 @@ getUserData
 	response := [ client get: url ] 
 		ensure: [ client close ].
 	
-	^ NeoJSONReader fromString: response
+	^ ZnUtils defaultJSONReader fromString: response

--- a/repository/Zinc-SSO-OAuth2-Core.package/ZnMicrosoftOAuth2Session.class/instance/getUserData.st
+++ b/repository/Zinc-SSO-OAuth2-Core.package/ZnMicrosoftOAuth2Session.class/instance/getUserData.st
@@ -9,4 +9,4 @@ getUserData
 
 	response := ZnClient new get: url.
 	
-	^ NeoJSONReader fromString: response
+	^ ZnUtils defaultJSONReader fromString: response

--- a/repository/Zinc-SSO-OAuth2-Core.package/ZnMicrosoftOAuth2Session.class/instance/handleAuthenticationCallback..st
+++ b/repository/Zinc-SSO-OAuth2-Core.package/ZnMicrosoftOAuth2Session.class/instance/handleAuthenticationCallback..st
@@ -18,6 +18,6 @@ handleAuthenticationCallback: aParameterDictionary
 	tokenResponse := ZnClient new 
 		request: tokenRequest ;
 		post.
-	tokenData := NeoJSONReader fromString: tokenResponse.
+	tokenData := ZnUtils defaultJSONReader fromString: tokenResponse.
 		
 	accessToken := tokenData at: 'access_token'

--- a/repository/Zinc-SSO-OAuth2-Core.package/ZnOAuth2Session.class/instance/handleAuthenticationCallback..st
+++ b/repository/Zinc-SSO-OAuth2-Core.package/ZnOAuth2Session.class/instance/handleAuthenticationCallback..st
@@ -22,4 +22,4 @@ handleAuthenticationCallback: aParameterDictionary
 		client request: tokenRequest;
 			post ] ensure: [ client close ].
 
-	self updateTokens: (NeoJSONReader fromString: tokenResponse).
+	self updateTokens: (ZnUtils defaultJSONReader fromString: tokenResponse).

--- a/repository/Zinc-SSO-OAuth2-Core.package/ZnOAuth2Session.class/instance/handleTokenRefresh.st
+++ b/repository/Zinc-SSO-OAuth2-Core.package/ZnOAuth2Session.class/instance/handleTokenRefresh.st
@@ -19,4 +19,4 @@ handleTokenRefresh
 		client request: tokenRequest;
 			post ] ensure: [ client close ].
 
-	self updateTokens: (NeoJSONReader fromString: tokenResponse).
+	self updateTokens: (ZnUtils defaultJSONReader fromString: tokenResponse).

--- a/repository/Zinc-SSO-OAuth2-Core.package/ZnOAuth2Session.class/instance/updateTokens..st
+++ b/repository/Zinc-SSO-OAuth2-Core.package/ZnOAuth2Session.class/instance/updateTokens..st
@@ -6,7 +6,7 @@ updateTokens: tokenData
 		ifTrue: [ ZnAuthError signal: (tokenData at: 'error') asString ].
 
 	accessToken := tokenData at: 'access_token'.
-	tokenType := tokenData at: 'token_type'.
+	tokenType := tokenData at: 'token_type' ifAbsent:[ 'Bearer' ]. "Bearer is the default type on most implementation, sometimes the auth server not always respond with the type"
 	(tokenData includesKey: 'expires_in')
 		ifTrue: [ self updateExpiration: (tokenData at: 'expires_in') ].
 	(tokenData includesKey: 'refresh_token')

--- a/repository/Zinc-SSO-OAuth2-Core.package/ZnOpenIDConnectDiscoveryDocument.class/class/fromUrl..st
+++ b/repository/Zinc-SSO-OAuth2-Core.package/ZnOpenIDConnectDiscoveryDocument.class/class/fromUrl..st
@@ -2,7 +2,7 @@ instance creation
 fromUrl: anUrl
 
 	^self new initializeWith: (
-		NeoJSONReader fromString: (
+		ZnUtils defaultJSONReader fromString: (
 			ZnClient new
 				accept: ZnMimeType applicationJson ;
 				get: anUrl))

--- a/repository/Zinc-SSO-OAuth2-Core.package/ZnOpenIDConnectSession.class/instance/getUserData.st
+++ b/repository/Zinc-SSO-OAuth2-Core.package/ZnOpenIDConnectSession.class/instance/getUserData.st
@@ -9,4 +9,4 @@ getUserData
 
 	response := ZnClient new get: url.
 	
-	^ NeoJSONReader fromString: response
+	^ ZnUtils defaultJSONReader fromString: response

--- a/repository/Zinc-SSO-OAuth2-Core.package/ZnOpenIDConnectSession.class/instance/handleAuthenticationCallback..st
+++ b/repository/Zinc-SSO-OAuth2-Core.package/ZnOpenIDConnectSession.class/instance/handleAuthenticationCallback..st
@@ -20,7 +20,7 @@ handleAuthenticationCallback: aParameterDictionary
 	tokenResponse := ZnClient new 
 		request: tokenRequest ;
 		post.
-	tokenData := NeoJSONReader fromString: tokenResponse.
+	tokenData := ZnUtils defaultJSONReader fromString: tokenResponse.
 		
 	self validateIdToken: (tokenData at: 'id_token').
 

--- a/repository/Zinc-Tests.package/ZnUtilsTest.class/instance/testDefaultJSONReader.st
+++ b/repository/Zinc-Tests.package/ZnUtilsTest.class/instance/testDefaultJSONReader.st
@@ -1,0 +1,11 @@
+testing
+testDefaultJSONReader
+	"System should provide a JSON parser"
+	| reader expectedParserClass |
+	reader := ZnUtils defaultJSONReader.
+	expectedParserClass := self class environment at: #NeoJSONObject ifAbsent: [ 
+		          self class environment at: #STONJSON ifAbsent:[nil]].
+	
+	self assert: reader notNil.
+	self assert: reader equals: expectedParserClass.
+	

--- a/repository/Zinc-Tests.package/ZnUtilsTest.class/instance/testDefaultJSONWriter.st
+++ b/repository/Zinc-Tests.package/ZnUtilsTest.class/instance/testDefaultJSONWriter.st
@@ -1,0 +1,10 @@
+testing
+testDefaultJSONWriter
+	"System should provide a JSON parser"
+	| writer expectedParserClass |
+	writer := ZnUtils defaultJSONWriter.
+	expectedParserClass := self class environment at: #NeoJSONWriter ifAbsent: [ 
+		          self class environment at: #STONJSON ifAbsent:[nil]].
+	
+	self assert: writer notNil.
+	self assert: writer equals: expectedParserClass.


### PR DESCRIPTION
This is now possible to load Zinc OAuth2 package directly from the package and to use it with the Pharo STONJSON parser.
+ Unit test
+ minor fixes
+ adding .gittatribute file to manage End of file encoding between Windows and others OS