### PR TITLE
Add support for Unix Domain Sockets: add missing connectTo: method

### DIFF
--- a/repository/Zinc-HTTP-UnixSocket.package/Socket.extension/instance/connectTo..st
+++ b/repository/Zinc-HTTP-UnixSocket.package/Socket.extension/instance/connectTo..st
@@ -1,0 +1,9 @@
+*Zinc-HTTP-UnixSocket
+connectTo: socketAddress
+	| status |
+	status := self primSocketConnectionStatus: socketHandle.
+	status == Unconnected
+		ifFalse: [ InvalidSocketStatusException
+				signal: 'Socket status must be unconnected before opening a new connection' ].
+
+	self primSocket: socketHandle connectTo: socketAddress

--- a/repository/Zinc-Tests.package/ZnUnixSocketClientTest.class/properties.json
+++ b/repository/Zinc-Tests.package/ZnUnixSocketClientTest.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "TestCase",
+	"category" : "Zinc-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "ZnUnixSocketClientTest",
+	"type" : "normal"
+}


### PR DESCRIPTION
In the context of the previous pull request https://github.com/svenvc/zinc/pull/120, there is a fix that adds `Socket >> #connectTo:` method.

Note: I accidentally added empty `ZnUnixSocketClientTest` class. I have not implemented test cases yet.