### PR TITLE
Initialize network before unix socket creation

### DIFF
--- a/repository/Zinc-HTTP-UnixSocket.package/ZnNetworkingUtils.extension/instance/unixSocketOnFile..st
+++ b/repository/Zinc-HTTP-UnixSocket.package/ZnNetworkingUtils.extension/instance/unixSocketOnFile..st
@@ -4,6 +4,7 @@ unixSocketOnFile: socketFile
 	socketFile exists ifFalse: [ 
 		ZnMissingUnixSocket new file: socketFile; signal ].
 	
+	NetNameResolver initializeNetwork.
 	NetNameResolver
 		primGetAddressInfoHost: ''
 		service: socketFile fullName


### PR DESCRIPTION
`NetNameResolver initializeNetwork` must be called before Socket creation.

Follow-up on https://github.com/svenvc/zinc/pull/120