### PR TITLE
Don't check for being in the middle of a codepoint when at end-of-stream (fixes #130)

### DIFF
--- a/repository/Zinc-Character-Encoding-Core.package/ZnUTF8Encoder.class/instance/ensureAtBeginOfCodePointOnStream..st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnUTF8Encoder.class/instance/ensureAtBeginOfCodePointOnStream..st
@@ -4,6 +4,8 @@ ensureAtBeginOfCodePointOnStream: stream
 	if not move further backwards. This is necessary when a position in the binary stream is set,
 	not knowing if that position is on a proper encoded character boundary."
 
+	"If we are at end-of-stream, we can't be in the middle of an encoded codepoint
+	(unless that codepoint is incomplete and thus invalid, which we won't worry about)"
+	stream atEnd ifTrue: [ ^ self ].
 	"Back up until we are not longer on a continuation byte but on a leading byte"
-
 	[ (stream peek bitAnd: 2r11000000) == 2r10000000 ] whileTrue: [ stream back ]

--- a/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Zinc-Character-Encoding-Core'!
+self packageOrganizer ensurePackage: #'Zinc-Character-Encoding-Core' withTags: #()!

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnCharacterStreamTest.class/instance/testUTF8ReadStreamPositioning.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnCharacterStreamTest.class/instance/testUTF8ReadStreamPositioning.st
@@ -17,4 +17,6 @@ testUTF8ReadStreamPositioning
 	stream position: 5.
 	self assert: stream next equals: $v.
 	stream position: 6.
-	self assert: stream next equals: $e
+	self assert: stream next equals: $e.
+	stream position: 7.
+	self assert: stream atEnd.

--- a/repository/Zinc-Character-Encoding-Tests.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Zinc-Character-Encoding-Tests'!
+self packageOrganizer ensurePackage: #'Zinc-Character-Encoding-Tests' withTags: #()!


### PR DESCRIPTION
If we #position: a character readStream and the argument corresponds to end-of-stream, we don't want to try to read off the end of the stream--but we can be sure that we're not in the middle of a (valid) codepoint, regardless.

I suppose we _could_ be in the middle of an _invalid_ codepoint, if the stream cuts off in the middle of one. For my use-case I'm not concerned about that, as I would never have gotten that far in the first place without an error. I also think if you had an incomplete codepoint in the middle of a stream, positioning the stream immediately after it wouldn't skip backwards or complain—so essentially I'm treating end-of-stream as an initial byte, and otherwise the behavior is the same as elsewhere.