### PR TITLE
Add #rawStream, analogous to #wrappedStream but accessing the innermost wrapped stream

### DIFF
--- a/repository/Zinc-Character-Encoding-Core.package/SocketStream.extension/instance/rawStream.st
+++ b/repository/Zinc-Character-Encoding-Core.package/SocketStream.extension/instance/rawStream.st
@@ -1,0 +1,7 @@
+*Zinc-Character-Encoding-Core
+rawStream
+	"Answer the innermost stream wrapped by the receiver, e.g. a raw binary file stream,
+	socket stream, or regular Read/WriteStream.
+	Since this the base stream, answer ourself."
+
+	^ self

--- a/repository/Zinc-Character-Encoding-Core.package/SocketStream.extension/instance/wrappedStream.st
+++ b/repository/Zinc-Character-Encoding-Core.package/SocketStream.extension/instance/wrappedStream.st
@@ -1,0 +1,6 @@
+*Zinc-Character-Encoding-Core
+wrappedStream
+	"Answer the stream that the receiver wraps.
+	Since this the base stream, answer nil"
+
+	^ nil

--- a/repository/Zinc-Character-Encoding-Core.package/SocketStream.extension/properties.json
+++ b/repository/Zinc-Character-Encoding-Core.package/SocketStream.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "SocketStream"
+}

--- a/repository/Zinc-Character-Encoding-Core.package/Stream.extension/instance/rawStream.st
+++ b/repository/Zinc-Character-Encoding-Core.package/Stream.extension/instance/rawStream.st
@@ -1,0 +1,7 @@
+*Zinc-Character-Encoding-Core
+rawStream
+	"Answer the innermost stream wrapped by the receiver, e.g. a raw binary file stream,
+	socket stream, or regular Read/WriteStream.
+	Since this the base stream, answer ourself."
+
+	^ self

--- a/repository/Zinc-Character-Encoding-Core.package/Stream.extension/instance/wrappedStream.st
+++ b/repository/Zinc-Character-Encoding-Core.package/Stream.extension/instance/wrappedStream.st
@@ -1,0 +1,6 @@
+*Zinc-Character-Encoding-Core
+wrappedStream
+	"Answer the stream that the receiver wraps.
+	Since this the base stream, answer nil"
+
+	^ nil

--- a/repository/Zinc-Character-Encoding-Core.package/Stream.extension/properties.json
+++ b/repository/Zinc-Character-Encoding-Core.package/Stream.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "Stream"
+}

--- a/repository/Zinc-Character-Encoding-Core.package/ZnBufferedReadStream.class/instance/rawStream.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnBufferedReadStream.class/instance/rawStream.st
@@ -1,0 +1,7 @@
+accessing
+rawStream
+	"Answer the innermost stream wrapped by the receiver, e.g. a raw binary file stream,
+	socket stream, or regular Read/WriteStream.
+	Defer to the wrappedStream."
+
+	^ self wrappedStream rawStream

--- a/repository/Zinc-Character-Encoding-Core.package/ZnBufferedReadWriteStream.class/instance/rawStream.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnBufferedReadWriteStream.class/instance/rawStream.st
@@ -1,0 +1,7 @@
+accessing
+rawStream
+	"Answer the innermost stream wrapped by the receiver, e.g. a raw binary file stream,
+	socket stream, or regular Read/WriteStream.
+	Defer to the wrappedStream."
+
+	^ self wrappedStream rawStream

--- a/repository/Zinc-Character-Encoding-Core.package/ZnBufferedWriteStream.class/instance/rawStream.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnBufferedWriteStream.class/instance/rawStream.st
@@ -1,0 +1,7 @@
+initialize-release
+rawStream
+	"Answer the innermost stream wrapped by the receiver, e.g. a raw binary file stream,
+	socket stream, or regular Read/WriteStream.
+	Defer to the wrappedStream."
+
+	^ self wrappedStream rawStream

--- a/repository/Zinc-Character-Encoding-Core.package/ZnBufferedWriteStream.class/instance/wrappedStream.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnBufferedWriteStream.class/instance/wrappedStream.st
@@ -1,0 +1,4 @@
+initialize-release
+wrappedStream
+
+	^ stream

--- a/repository/Zinc-Character-Encoding-Core.package/ZnEncodedStream.class/instance/rawStream.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnEncodedStream.class/instance/rawStream.st
@@ -1,0 +1,7 @@
+accessing
+rawStream
+	"Answer the innermost stream wrapped by the receiver, e.g. a raw binary file stream,
+	socket stream, or regular Read/WriteStream.
+	Defer to the wrappedStream."
+
+	^ self wrappedStream rawStream

--- a/repository/Zinc-Character-Encoding-Core.package/ZnNewLineWriterStream.class/instance/rawStream.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnNewLineWriterStream.class/instance/rawStream.st
@@ -1,0 +1,7 @@
+accessing
+rawStream
+	"Answer the innermost stream wrapped by the receiver, e.g. a raw binary file stream,
+	socket stream, or regular Read/WriteStream.
+	Defer to the wrappedStream."
+
+	^ self wrappedStream rawStream

--- a/repository/Zinc-Character-Encoding-Core.package/ZnPositionableReadStream.class/instance/rawStream.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnPositionableReadStream.class/instance/rawStream.st
@@ -1,0 +1,7 @@
+accessing
+rawStream
+	"Answer the innermost stream wrapped by the receiver, e.g. a raw binary file stream,
+	socket stream, or regular Read/WriteStream.
+	Defer to the wrappedStream."
+
+	^ self wrappedStream rawStream

--- a/repository/Zinc-HTTP.package/ZnHtmlOutputStream.class/instance/rawStream.st
+++ b/repository/Zinc-HTTP.package/ZnHtmlOutputStream.class/instance/rawStream.st
@@ -1,0 +1,7 @@
+accessing
+rawStream
+	"Answer the innermost stream wrapped by the receiver, e.g. a raw binary file stream,
+	socket stream, or regular Read/WriteStream.
+	Defer to the wrappedStream."
+
+	^ self wrappedStream rawStream

--- a/repository/Zinc-HTTP.package/ZnLoggingReadStream.class/instance/rawStream.st
+++ b/repository/Zinc-HTTP.package/ZnLoggingReadStream.class/instance/rawStream.st
@@ -1,0 +1,7 @@
+accessing
+rawStream
+	"Answer the innermost stream wrapped by the receiver, e.g. a raw binary file stream,
+	socket stream, or regular Read/WriteStream.
+	Defer to the wrappedStream."
+
+	^ self wrappedStream rawStream

--- a/repository/Zinc-HTTP.package/monticello.meta/categories.st
+++ b/repository/Zinc-HTTP.package/monticello.meta/categories.st
@@ -1,8 +1,1 @@
-SystemOrganization addCategory: #'Zinc-HTTP'!
-SystemOrganization addCategory: #'Zinc-HTTP-Client-Server'!
-SystemOrganization addCategory: #'Zinc-HTTP-Core'!
-SystemOrganization addCategory: #'Zinc-HTTP-Exceptions'!
-SystemOrganization addCategory: #'Zinc-HTTP-Logging'!
-SystemOrganization addCategory: #'Zinc-HTTP-Streaming'!
-SystemOrganization addCategory: #'Zinc-HTTP-Support'!
-SystemOrganization addCategory: #'Zinc-HTTP-Variables'!
+self packageOrganizer ensurePackage: #'Zinc-HTTP' withTags: #(#'Client-Server' #Core #Exceptions #Logging #Streaming #Support #Variables)!


### PR DESCRIPTION
Getting from the return value of `'foo.txt' asFileReference readStream` to the actual `BinaryFileStream` is already two sends of `wrappedStream`, and if it's already been wrapped in e.g. a `ZnNewLineWriterStream` that's now three, or a loop if you don't know. Seems like it would be useful to have one-step access to the underlying "raw" stream for any Zinc stream.

I also took the opportunity to add `ZnBufferedWriteStream>>wrappedStream` as this was the only class that did not already understand it, and also make `Stream` polymorphic with the Zinc classes by adding `wrappedStream` and `rawStream` implementations there.