### PR TITLE
Cleanup: ZnCharacterEncoder, ZnEncodedStream, ZnEncodedReadStream and ZnEncodedWriteStream should be abstract classes

### DIFF
--- a/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncoder.class/class/isAbstract.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnCharacterEncoder.class/class/isAbstract.st
@@ -1,0 +1,4 @@
+testing
+isAbstract
+
+	^ self == ZnCharacterEncoder

--- a/repository/Zinc-Character-Encoding-Core.package/ZnEncodedReadStream.class/class/isAbstract.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnEncodedReadStream.class/class/isAbstract.st
@@ -1,0 +1,4 @@
+testing
+isAbstract
+
+	^ self == ZnEncodedReadStream

--- a/repository/Zinc-Character-Encoding-Core.package/ZnEncodedStream.class/class/isAbstract.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnEncodedStream.class/class/isAbstract.st
@@ -1,0 +1,4 @@
+testing
+isAbstract
+
+	^ self == ZnEncodedStream

--- a/repository/Zinc-Character-Encoding-Core.package/ZnEncodedWriteStream.class/class/isAbstract.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnEncodedWriteStream.class/class/isAbstract.st
@@ -1,0 +1,4 @@
+testing
+isAbstract
+
+	^ self == ZnEncodedWriteStream

--- a/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Zinc-Character-Encoding-Core'!
+self packageOrganizer ensurePackage: #'Zinc-Character-Encoding-Core' withTags: #()!

--- a/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-self packageOrganizer ensurePackage: #'Zinc-Character-Encoding-Core' withTags: #()!
+SystemOrganization addCategory: #'Zinc-Character-Encoding-Core'!


### PR DESCRIPTION
 

Fix #139 and https://github.com/pharo-project/pharo/issues/16708