### PR TITLE
Fix ZnBufferedWriteStream does not support #reset

### DIFF
--- a/repository/Zinc-Character-Encoding-Core.package/ZnBufferedWriteStream.class/instance/reset.st
+++ b/repository/Zinc-Character-Encoding-Core.package/ZnBufferedWriteStream.class/instance/reset.st
@@ -1,0 +1,4 @@
+accessing
+reset
+	self flushBuffer.
+	stream reset

--- a/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Zinc-Character-Encoding-Core'!
+self packageOrganizer ensurePackage: #'Zinc-Character-Encoding-Core' withTags: #()!

--- a/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Core.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-self packageOrganizer ensurePackage: #'Zinc-Character-Encoding-Core' withTags: #()!
+SystemOrganization addCategory: #'Zinc-Character-Encoding-Core'!

--- a/repository/Zinc-Character-Encoding-Tests.package/ZnBufferedWriteStreamTest.class/instance/testWritingReset.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/ZnBufferedWriteStreamTest.class/instance/testWritingReset.st
@@ -1,0 +1,14 @@
+tests
+testWritingReset
+
+	| file writeStream readStream |
+	file := 'test.txt' asFileReference ensureCreateFile.
+
+	writeStream := file binaryWriteStream.
+	writeStream nextPutAll: 'pedro'.
+	writeStream reset.
+	writeStream nextPutAll: 'pha'.
+	writeStream close.
+
+	readStream := file readStream.
+	self assert: readStream contents equals: 'pharo'

--- a/repository/Zinc-Character-Encoding-Tests.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-self packageOrganizer ensurePackage: #'Zinc-Character-Encoding-Tests' withTags: #()!
+SystemOrganization addCategory: #'Zinc-Character-Encoding-Tests'!

--- a/repository/Zinc-Character-Encoding-Tests.package/monticello.meta/categories.st
+++ b/repository/Zinc-Character-Encoding-Tests.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Zinc-Character-Encoding-Tests'!
+self packageOrganizer ensurePackage: #'Zinc-Character-Encoding-Tests' withTags: #()!


### PR DESCRIPTION
Fix https://github.com/pharo-project/pharo/issues/16718 in the Pharo repo
Added a `reset` method to ZnBufferedWriteStream
Also added a test for the `reset` method
Had to add a few commits to revert changes on how Pharo viewed the packages
Duplicate of https://github.com/pharo-project/pharo/pull/16727 in the Pharo repo